### PR TITLE
Enhance command-line error handling and add LLVM library directory op…

### DIFF
--- a/compiler/Driver/Driver.cpp
+++ b/compiler/Driver/Driver.cpp
@@ -151,6 +151,7 @@ Driver::Driver(llvm::ArrayRef<const char *> ArrArgs) :
     app.add_option("--src-dir",     SrcDirs,      "Source root directory: inputs and import-based dependencies are discovered here (default: current directory)")->allow_extra_args(false);
     app.add_option("--out-dir",     OutDirOpt,    "Directory for all generated build outputs (created if missing)");
     app.add_option("--link-lib",   LinkLibs,     "Link against external C library NAME (passed as -lNAME to the linker)")->allow_extra_args(false);
+    app.add_option("--llvm-lib-dir", LlvmLibDir, "Directory holding the LLVM libraries (libLLVM-20.so / LLVM-20.lib) for programs using the LLVM C-API (default: probed next to the fly binary)");
 
     // No positional arguments exist: fly compiles a source DIRECTORY (--src-dir,
     // default: current directory), never named files. Extras are kept only to be
@@ -164,6 +165,7 @@ Driver::Driver(llvm::ArrayRef<const char *> ArrArgs) :
             llvm::errs() << "error: " << e.what() << "\n";
             llvm::errs() << "Use '" << Path << " --help' for a complete list of options.\n";
             doExecute = false;
+            HadOptionError = true;
         }
         return;
     }
@@ -186,6 +188,7 @@ Driver::Driver(llvm::ArrayRef<const char *> ArrArgs) :
                             " (default: current directory)\n";
         }
         doExecute = false;
+        HadOptionError = true;
         return;
     }
 
@@ -333,6 +336,7 @@ void Driver::BuildOptions(FileSystemOptions &FileSystemOpts,
     if (SrcDirs.size() > 1) {
         llvm::errs() << "error: --src-dir may be specified only once\n";
         doExecute = false;
+        HadOptionError = true;
         return;
     }
     for (const auto &D : SrcDirs) {
@@ -361,6 +365,34 @@ void Driver::BuildOptions(FileSystemOptions &FileSystemOpts,
         }
     }
 
+    // LLVM lib dir → linker search path (-L / /libpath:), so programs that use
+    // the LLVM C-API (the compiler's own CodeGen/Target suites reference
+    // libLLVM-20.so → -lLLVM-20) link against the fork LLVM without a system
+    // install. Probe order mirrors the self-host ToolChain.getLLVMLibDir():
+    // the --llvm-lib-dir override, then <exe_dir>/llvm/lib (release bundle),
+    // then <exe_dir>/../llvm/lib (this repo's build tree: build/bin →
+    // build/llvm/lib), then <exe_dir>/../../llvm/lib (staged bootstrap:
+    // build/stage0/bin → build/llvm/lib). Left empty when none exists —
+    // ordinary user programs don't reference LLVM.
+    {
+        namespace fs = std::filesystem;
+        std::error_code ec;
+        if (!LlvmLibDir.empty() && fs::is_directory(LlvmLibDir, ec)) {
+            CodeGenOpts->ToolchainLibDir = LlvmLibDir;
+        } else {
+            for (const fs::path &Candidate : {fs::path(Dir) / "llvm" / "lib",
+                                              fs::path(Dir) / ".." / "llvm" / "lib",
+                                              fs::path(Dir) / ".." / ".." / "llvm" / "lib"}) {
+                auto canon = fs::canonical(Candidate, ec);
+                if (!ec && fs::is_directory(canon, ec)) {
+                    CodeGenOpts->ToolchainLibDir = canon.string();
+                    FLY_DEBUG_MSG("Set ToolchainLibDir=" << CodeGenOpts->ToolchainLibDir);
+                    break;
+                }
+            }
+        }
+    }
+
     // External C libraries to link (--link-lib NAME → -lNAME in linker flags)
     for (const auto &Lib : LinkLibs) {
         std::string Flag = "-l" + Lib;
@@ -382,6 +414,7 @@ void Driver::BuildOptions(FileSystemOptions &FileSystemOpts,
         if (NoOutput) {
             llvm::errs() << "cannot specify -o with --no-output\n";
             doExecute = false;
+            HadOptionError = true;
             return;
         }
         FLY_DEBUG_MSG("Set -o=" << OutputFile);
@@ -425,16 +458,19 @@ void Driver::BuildOptions(FileSystemOptions &FileSystemOpts,
     if (OutputLib && OutputShared) {
         llvm::errs() << "cannot specify both --lib and --lib-dyn\n";
         doExecute = false;
+        HadOptionError = true;
         return;
     }
     if (WantsLibrary && NonObjFormat) {
         llvm::errs() << "cannot specify --lib/--lib-dyn with --emit-ll/--emit-bc/--emit-as\n";
         doExecute = false;
+        HadOptionError = true;
         return;
     }
     if (WantsLibrary && (CompileOnly || NoOutput)) {
         llvm::errs() << "cannot specify --lib/--lib-dyn with -c or --no-output\n";
         doExecute = false;
+        HadOptionError = true;
         return;
     }
 
@@ -578,6 +614,11 @@ void Driver::printVersion(bool full) {
 
 bool Driver::Execute() {
     FLY_DEBUG_SCOPE("Driver", "Execute");
+    // A command-line error is a FAILURE (exit 1) even though nothing executes —
+    // matching the self-host driver. --help/--version stay a successful no-op.
+    if (HadOptionError)
+        return false;
+
     bool Success = true;
 
     if (doExecute) {

--- a/compiler/Driver/ToolChain.cpp
+++ b/compiler/Driver/ToolChain.cpp
@@ -543,8 +543,9 @@ bool ToolChain::LinkWindows(const llvm::SmallVector<std::string, 4> &InFiles, co
     if (CodeGenOpts.DebugSymbols)
         CmdArgs.push_back("/debug:dwarf");
 
-    // Toolchain LLVM lib dir, auto-discovered as <fly_bin>/../llvm/lib.
-    // Lets native [link] deps (e.g. LLVM-20.lib) resolve without a manual LIB setup.
+    // Toolchain LLVM lib dir (--llvm-lib-dir override or probed exe-relative by
+    // the Driver). Lets native LLVM deps (e.g. LLVM-20.lib) resolve without a
+    // manual LIB setup.
     if (!CodeGenOpts.ToolchainLibDir.empty())
         CmdArgs.push_back("/libpath:" + CodeGenOpts.ToolchainLibDir);
 
@@ -559,6 +560,9 @@ bool ToolChain::LinkWindows(const llvm::SmallVector<std::string, 4> &InFiles, co
     // auto-link it — link it explicitly. Mirrors runtime/CMakeLists.txt.
     CmdArgs.push_back("/defaultlib:synchronization");
     CmdArgs.push_back("/defaultlib:kernel32");
+    // ntdll: the 0.14 runtime's env_kernel*/RtlGetVersion — needed when this
+    // toolchain (as the seed) links programs against that runtime archive.
+    CmdArgs.push_back("/defaultlib:ntdll");
 
     // Check the environment first, since that's probably the user telling us
     // what they want to use.
@@ -846,7 +850,11 @@ bool ToolChain::LinkLinux(const llvm::SmallVector<std::string, 4> &InFiles, cons
     llvm::SmallVector<std::string, 16> CmdArgs;
     CmdArgs.push_back("ld");
 
-    // Toolchain LLVM lib dir, auto-discovered as <fly_bin>/../llvm/lib.
+    // Toolchain LLVM lib dir (--llvm-lib-dir override or probed exe-relative by
+    // the Driver), so programs that use the LLVM C-API (the compiler's own
+    // CodeGen/Target test suites reference libLLVM-20.so → -lLLVM-20) link
+    // against the fork LLVM without a system install. Empty for ordinary
+    // programs on a host without the bundle layout — then nothing is added.
     if (!CodeGenOpts.ToolchainLibDir.empty())
         CmdArgs.push_back("-L" + CodeGenOpts.ToolchainLibDir);
 

--- a/compiler/Frontend/Frontend.cpp
+++ b/compiler/Frontend/Frontend.cpp
@@ -791,18 +791,24 @@ void Frontend::ResolveSourceDeps(ASTBuilder &Builder) {
                 }
             }
 
-            // Namespaces to pull: the imported one plus every DESCENDANT namespace
-            // (an `import my` / `import my.*` must discover my.utils from source —
-            // in directory mode nothing else brings those files in). Header-served
-            // descendants stay with their archives.
+            // Namespaces to pull: the imported one, or — ONLY when no file
+            // declares that exact namespace — its DESCENDANTS (an `import my` /
+            // `import my.*` must discover my.utils from source; in directory mode
+            // nothing else brings those files in). When the exact namespace IS
+            // declared, its files alone are the import's meaning: pulling
+            // descendants too would drag sibling trees in (e.g. the compiler's
+            // own `fly.compiler.codegen.*` TEST suites into a compiler build).
+            // Header-served descendants stay with their archives either way.
             llvm::SmallVector<std::string, 4> MatchNs;
-            if (NsToFiles.count(ns))
+            if (NsToFiles.count(ns)) {
                 MatchNs.push_back(ns);
-            const std::string Prefix = ns + ".";
-            for (const auto &Entry : NsToFiles)
-                if (llvm::StringRef(Entry.first).starts_with(Prefix) &&
-                    !HeaderNs.count(Entry.first))
-                    MatchNs.push_back(Entry.first);
+            } else {
+                const std::string Prefix = ns + ".";
+                for (const auto &Entry : NsToFiles)
+                    if (llvm::StringRef(Entry.first).starts_with(Prefix) &&
+                        !HeaderNs.count(Entry.first))
+                        MatchNs.push_back(Entry.first);
+            }
             // A plain/alias import is `Namespace.Symbol` (e.g. `import fly.compiler.ast.ASTNode`):
             // its trailing component is the imported class/enum/function name, NOT a namespace
             // component, so the joined path is not a declared namespace. Fall back to the parent
@@ -922,11 +928,8 @@ bool Frontend::DiscoverInputs() {
         return std::string(llvm::sys::path::filename(Abs));
     };
 
-    // Library builds compile the whole directory (the directory IS the library),
-    // and so do the non-linking stages (--no-output, -c, --emit-*): with no
-    // executable to produce there is no entry point to choose. main()/suite
-    // selection below only exists to pick what gets linked.
-    if (FO.CreateLibrary || FO.CreateSharedLib || !FO.LinkStep) {
+    // Library builds compile the whole directory: the directory IS the library.
+    if (FO.CreateLibrary || FO.CreateSharedLib) {
         for (const auto &F : Files)
             FO.addInputFile(F.c_str());
         FO.DefaultOutputStem = RootStem();
@@ -948,8 +951,10 @@ bool Frontend::DiscoverInputs() {
                                  << " suites=" << Suites.size());
     }
 
-    // Test mode (--test / --suite): the suites are the entry points.
-    if (CGO.TestMode) {
+    // Test mode (--test / --suite) on a linking build: the suites are the entry
+    // points. Non-linking test-mode builds fall through to the main()/whole-dir
+    // rules below (compiling suites to objects needs no suite selection).
+    if (CGO.TestMode && FO.LinkStep) {
         if (!CGO.SuiteName.empty()) {
             llvm::StringSet<> Chosen;
             for (const auto &SD : SuiteDecls)
@@ -980,8 +985,18 @@ bool Frontend::DiscoverInputs() {
         // is the historical "test executable running its test {} blocks".
     }
 
-    // Executable build: exactly one top-level main() under the root.
+    // One top-level main() under the root selects the entry (its import closure
+    // pulls the rest) — for the non-linking stages too, so `-c --src-dir <proj>`
+    // compiles the PROGRAM, not every stray test source in the tree. With no
+    // main at all, a non-linking build has no entry to choose and compiles the
+    // whole directory; a linking build has nothing to link.
     if (MainFiles.empty()) {
+        if (!FO.LinkStep) {
+            for (const auto &F : Files)
+                FO.addInputFile(F.c_str());
+            FO.DefaultOutputStem = RootStem();
+            return true;
+        }
         Diags.Report(diag::err_fe_no_main) << Root;
         return false;
     }

--- a/include/Basic/CodeGenOptions.h
+++ b/include/Basic/CodeGenOptions.h
@@ -156,10 +156,13 @@ public:
   /// as <fly_bin>/../lib (same as StdLibDir).
   std::string RuntimeLibDir;
 
-  /// Toolchain library directory (LLVM import/static libs: LLVM-20.lib,
-  /// LLVM-C.lib, …) — auto-discovered by the Driver as <fly_bin>/../llvm/lib
-  /// (relative-to-binary). Added to the linker search path so native deps
-  /// declared in [link] resolve without a manual LIB setup.
+  /// Toolchain LLVM library directory (libLLVM-20.so / LLVM-20.lib), set by
+  /// the Driver: the --llvm-lib-dir override, else probed relative to the fly
+  /// binary — <exe_dir>/llvm/lib (release bundle), <exe_dir>/../llvm/lib (this
+  /// repo's build tree: build/bin → build/llvm/lib), then <exe_dir>/../../llvm/lib
+  /// (staged bootstrap: build/stage0/bin → build/llvm/lib). Added to the linker
+  /// search path (-L / /libpath:) so programs using the LLVM C-API link against
+  /// the fork LLVM without a system install. Empty when none exists.
   std::string ToolchainLibDir;
 
   /// The filename with path we use for coverage data files. The runtime

--- a/include/Driver/Driver.h
+++ b/include/Driver/Driver.h
@@ -29,6 +29,12 @@ namespace fly {
         // Can go ahead with execute phase
         bool doExecute = true;
 
+        // A command-line error occurred (unknown option, unexpected positional,
+        // conflicting options): Execute() is a no-op that returns FAILURE, so the
+        // process exits 1 — matching the self-host driver. --help/--version also
+        // clear doExecute but are not errors and keep exit 0.
+        bool HadOptionError = false;
+
         /// The name the driver was invoked as.
         std::string Name;
 
@@ -48,6 +54,7 @@ namespace fly {
         std::vector<std::string> LibDirs;
         std::vector<std::string> SrcDirs;   // --src-dir flags: source search paths for import-based dep discovery
         std::vector<std::string> LinkLibs;  // --link-lib flags: external C libs to link (-lNAME)
+        std::string LlvmLibDir;             // --llvm-lib-dir: dir holding the LLVM libs (libLLVM-20.so / LLVM-20.lib)
         std::string OutDirOpt;              // --out-dir: directory for all generated build outputs
         std::string OutputFile;
         // Linked-artifact shape (an axis of its own: it says what the LINK step

--- a/test/AppTest.cpp
+++ b/test/AppTest.cpp
@@ -131,9 +131,9 @@ void main() {
     }
 
     // ─── Driver: emit formats ─────────────────────────────────────────────────
-    // A non-linking stage compiles the whole directory: every source is an
-    // explicit input, so without -o each file gets its own artifact (per-file
-    // emission, exactly as the old multi-file CLI behaved).
+    // The single main() selects the entry even on a non-linking stage; utils.fly
+    // is PULLED through the import, so emit builds lower everything into ONE
+    // module: exactly one artifact, named after the entry, never one per file.
 
     TEST_F(AppTest, EmitLL) {
         deleteFile("main.fly.ll");
@@ -145,10 +145,9 @@ void main() {
         ASSERT_TRUE(drv.Execute());
 
         EXPECT_TRUE(std::ifstream("main.fly.ll").good());
-        EXPECT_TRUE(std::ifstream("utils.fly.ll").good());
+        EXPECT_FALSE(std::ifstream("utils.fly.ll").good());
 
         deleteFile("main.fly.ll");
-        deleteFile("utils.fly.ll");
     }
 
     TEST_F(AppTest, EmitBC) {
@@ -161,10 +160,9 @@ void main() {
         ASSERT_TRUE(drv.Execute());
 
         EXPECT_TRUE(std::ifstream("main.fly.bc").good());
-        EXPECT_TRUE(std::ifstream("utils.fly.bc").good());
+        EXPECT_FALSE(std::ifstream("utils.fly.bc").good());
 
         deleteFile("main.fly.bc");
-        deleteFile("utils.fly.bc");
     }
 
     TEST_F(AppTest, EmitAS) {
@@ -177,10 +175,9 @@ void main() {
         ASSERT_TRUE(drv.Execute());
 
         EXPECT_TRUE(std::ifstream("main.fly.s").good());
-        EXPECT_TRUE(std::ifstream("utils.fly.s").good());
+        EXPECT_FALSE(std::ifstream("utils.fly.s").good());
 
         deleteFile("main.fly.s");
-        deleteFile("utils.fly.s");
     }
 
     // Explicit -o with an emit action: the single combined artifact is written

--- a/test/DriverTest.cpp
+++ b/test/DriverTest.cpp
@@ -64,8 +64,8 @@ namespace {
         const char *argv[] = {"fly", "--unknown-opt"};
         Driver driver(argv);
         driver.BuildCompilerInstance();
-        // doExecute=false after unknown option → Execute() returns true (no crash)
-        EXPECT_TRUE(driver.Execute());
+        // A CLI error is a FAILURE: Execute() is a no-op returning false → exit 1.
+        EXPECT_FALSE(driver.Execute());
     }
 
     // Positional arguments are rejected: sources are never named on the command
@@ -74,8 +74,8 @@ namespace {
         const char *argv[] = {"fly", "file1.fly"};
         Driver driver(argv);
         CompilerInstance &CI = driver.BuildCompilerInstance();
-        // doExecute=false → Execute() returns true without compiling anything.
-        EXPECT_TRUE(driver.Execute());
+        // A CLI error is a FAILURE (exit 1); nothing was compiled.
+        EXPECT_FALSE(driver.Execute());
         EXPECT_TRUE(CI.getFrontendOptions().getInputFiles().empty());
     }
 
@@ -286,14 +286,14 @@ namespace {
         EXPECT_TRUE(CI.getFrontendOptions().CreateSharedLib);
     }
 
-    // --shared was the pre-0.13.9 spelling and is gone: the dynamic library is
+    // --shared was an old spelling and is gone: the dynamic library is
     // requested with --lib-dyn / --lib-dynamic only. It must be rejected as an
-    // unknown option.
+    // unknown option (a CLI error → Execute() false, exit 1).
     TEST_F(DriverTest, SharedFlagIsGone) {
         const char *argv[] = {"fly", "--shared", "-o", "out"};
         Driver driver(argv);
         CompilerInstance &CI = driver.BuildCompilerInstance();
-        EXPECT_TRUE(driver.Execute());
+        EXPECT_FALSE(driver.Execute());
         EXPECT_FALSE(CI.getFrontendOptions().CreateSharedLib);
     }
 
@@ -305,7 +305,7 @@ namespace {
         const char *argv[] = {"fly", "--lib", "-emit-ll", "-o", "out.ll"};
         Driver driver(argv);
         CompilerInstance &CI = driver.BuildCompilerInstance();
-        EXPECT_TRUE(driver.Execute());  // rejected cleanly, no crash
+        EXPECT_FALSE(driver.Execute());  // rejected cleanly: a CLI error → exit 1
         // The driver bailed out before applying either axis.
         EXPECT_NE(CI.getFrontendOptions().BackendAction, BackendActionKind::Backend_EmitLL);
         EXPECT_FALSE(CI.getFrontendOptions().CreateLibrary);
@@ -315,7 +315,7 @@ namespace {
         const char *argv[] = {"fly", "--lib", "-c", "-o", "out"};
         Driver driver(argv);
         CompilerInstance &CI = driver.BuildCompilerInstance();
-        EXPECT_TRUE(driver.Execute());
+        EXPECT_FALSE(driver.Execute());
         EXPECT_FALSE(CI.getFrontendOptions().CreateLibrary);
     }
 
@@ -323,19 +323,20 @@ namespace {
         const char *argv[] = {"fly", "--lib", "--lib-dyn", "-o", "out"};
         Driver driver(argv);
         CompilerInstance &CI = driver.BuildCompilerInstance();
-        EXPECT_TRUE(driver.Execute());
+        EXPECT_FALSE(driver.Execute());
         EXPECT_FALSE(CI.getFrontendOptions().CreateLibrary);
         EXPECT_FALSE(CI.getFrontendOptions().CreateSharedLib);
     }
 
     // ─── Output conflict detection ────────────────────────────────────────────
-    // --no-output emits nothing, so naming an output makes no sense: still rejected.
+    // --no-output emits nothing, so naming an output makes no sense: rejected as
+    // a CLI error (Execute() false → exit 1).
 
     TEST_F(DriverTest, OutputConflictWithNoOutput) {
         const char *argv[] = {"fly", "-no-output", "-o", "out.o"};
         Driver driver(argv);
         driver.BuildCompilerInstance();
-        EXPECT_TRUE(driver.Execute());
+        EXPECT_FALSE(driver.Execute());
     }
 
     // ─── Stats / timers ───────────────────────────────────────────────────────

--- a/test/SingleFileBuildTest.cpp
+++ b/test/SingleFileBuildTest.cpp
@@ -346,7 +346,8 @@ namespace {
                               "-o", "sfb_dep_twice/main.a"};
         Driver drv(argv);
         drv.BuildCompilerInstance();
-        drv.Execute();   // no-op: the option error stops the driver
+        // The option error stops the driver AND is a failure (exit 1).
+        EXPECT_FALSE(drv.Execute());
         EXPECT_FALSE(exists("sfb_dep_twice/main.a"));
     }
 


### PR DESCRIPTION
…tion

- Introduced `--llvm-lib-dir` option for specifying the directory of LLVM libraries.
- Updated error handling to ensure command-line errors result in a failure state.
- Refactored related comments and tests to reflect the new error handling behavior.